### PR TITLE
Fix buffer allocation so repeated calls to Deflate64.decompress succeed

### DIFF
--- a/tests/test_deflate64.py
+++ b/tests/test_deflate64.py
@@ -37,13 +37,12 @@ def test_decompress_output_type(data_dir, deflate64):
     assert isinstance(decompressed_content, bytes)
 
 
-@pytest.mark.xfail(raises=SystemError)
 def test_decompress_repeated(data_dir, deflate64):
     """Ensure that resources are properly shared by repeated invocations of Deflate64.decompress."""
     with open(data_dir / '10_lines.deflate64', 'rb') as compressed_content_stream:
         decompressed_content_10 = deflate64.decompress(compressed_content_stream.read())
 
-    with open(data_dir / '10_lines.deflate64', 'rb') as compressed_content_stream:
+    with open(data_dir / '100_lines.deflate64', 'rb') as compressed_content_stream:
         decompressed_content_100 = deflate64.decompress(compressed_content_stream.read())
 
     assert len(decompressed_content_10) == 180

--- a/zipfile_deflate64/deflate64/deflate64module.c
+++ b/zipfile_deflate64/deflate64/deflate64module.c
@@ -73,7 +73,6 @@ static int Deflate64_init(Deflate64Object* self, PyObject* args, PyObject* kwds)
 }
 
 static void Deflate64_dealloc(Deflate64Object* self) {
-    Py_XDECREF(self->output_buffer);
     if (self->strm != NULL) {
         int err = inflateBack9End(self->strm);
         switch (err) {
@@ -184,13 +183,15 @@ static PyObject* Deflate64_decompress(Deflate64Object* self, PyObject *args) {
             goto error;
     }
 
-    // This method returns a new reference to output_buffer, which should persist even after this
-    // object is deallocated (which decrements output_buffer)
+    // This method returns a new reference to output_buffer
     Py_INCREF(self->output_buffer);
     ret = self->output_buffer;
 
 error:
     PyBuffer_Release(&input_buffer);
+    // Release and clear the internal reference to output_buffer, as it's intended to only be
+    // used during the lifetime of this decompress function
+    Py_CLEAR(self->output_buffer);
     return ret;
 }
 

--- a/zipfile_deflate64/deflate64/deflate64module.c
+++ b/zipfile_deflate64/deflate64/deflate64module.c
@@ -66,13 +66,6 @@ static int Deflate64_init(Deflate64Object* self, PyObject* args, PyObject* kwds)
             return -1;
     }
 
-    // Allocate now, but with no size; this will be resized later
-    self->output_buffer = PyBytes_FromStringAndSize(NULL, 0);
-    if (self->output_buffer == NULL) {
-        PyErr_NoMemory();
-        return -1;
-    }
-
     // Default eof to false
     self->eof = 0;
 
@@ -146,6 +139,13 @@ static PyObject* Deflate64_decompress(Deflate64Object* self, PyObject *args) {
     Py_buffer input_buffer;
     if (!PyArg_ParseTuple(args, "y*", &input_buffer)) {
         return NULL;
+    }
+
+    // Allocate now, but with no size; this will be resized later
+    self->output_buffer = PyBytes_FromStringAndSize(NULL, 0);
+    if (self->output_buffer == NULL) {
+        PyErr_NoMemory();
+        return -1;
     }
 
     self->strm->next_in = input_buffer.buf;

--- a/zipfile_deflate64/deflate64/deflate64module.c
+++ b/zipfile_deflate64/deflate64/deflate64module.c
@@ -145,7 +145,7 @@ static PyObject* Deflate64_decompress(Deflate64Object* self, PyObject *args) {
     self->output_buffer = PyBytes_FromStringAndSize(NULL, 0);
     if (self->output_buffer == NULL) {
         PyErr_NoMemory();
-        return -1;
+        return NULL;
     }
 
     self->strm->next_in = input_buffer.buf;


### PR DESCRIPTION
This was originally opened as #18.